### PR TITLE
Fix build when using NDK r12b

### DIFF
--- a/Maps.cpp
+++ b/Maps.cpp
@@ -20,6 +20,7 @@
 #include <inttypes.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <sys/mman.h>
 #include <sys/types.h>
 #include <unistd.h>


### PR DESCRIPTION
This changeset fixes compilation breakage on NDK r12b introduced in 43cd76cc243681d4224812369a689f962a39192e:

```
FAILED: /usr/local/android-sdk/ndk-bundle/toolchains/llvm/prebuilt/linux-x86_64/bin/clang++  -target x86_64-none-linux-android -gcc-toolchain /usr/local/android-sdk/ndk-bundle/toolchains/x86_64-4.9/prebuilt/linux-x86_64 --sysroot=/usr/local/android-sdk/ndk-bundle/platforms/android-21/arch-x86_64  -DEM_ARM=40 -I../../../../src/main/jni -I../../../../src/main/jni/deps -I../../../../src/main/jni/external/libunwind/include -I../../../../src/main/jni/external/libunwindstack/include -I../../../../src/main/jni/external/libunwindstack/cmake/.. -I../../../../src/main/jni/external/libunwindstack/cmake/../include -isystem /usr/local/android-sdk/ndk-bundle/sources/cxx-stl/llvm-libc++/libcxx/include -isystem /usr/local/android-sdk/ndk-bundle/sources/android/support/include -isystem /usr/local/android-sdk/ndk-bundle/sources/cxx-stl/llvm-libc++abi/libcxxabi/include -g -DANDROID -ffunction-sections -funwind-tables -fstack-protector-strong -no-canonical-prefixes -Wa,--noexecstack -Wformat -Werror=format-security -fno-exceptions -fno-rtti -std=c++11 -fexceptions -g -DANDROID -ffunction-sections -funwind-tables -fstack-protector-strong -no-canonical-prefixes -Wa,--noexecstack -Wformat -Werror=format-security -fno-exceptions -fno-rtti -std=c++11 -fexceptions  -std=c++11 -O0 -fno-limit-debug-info -O0 -fno-limit-debug-info  -fPIC -MD -MT src/main/jni/external/libunwindstack/cmake/CMakeFiles/unwindstack.dir/__/Maps.cpp.o -MF src/main/jni/external/libunwindstack/cmake/CMakeFiles/unwindstack.dir/__/Maps.cpp.o.d -o src/main/jni/external/libunwindstack/cmake/CMakeFiles/unwindstack.dir/__/Maps.cpp.o -c /home/travis/build/bugsnag/bugsnag-android/sdk/src/main/jni/external/libunwindstack/Maps.cpp
  /home/travis/build/bugsnag/bugsnag-android/sdk/src/main/jni/external/libunwindstack/Maps.cpp:70:20: error: use of undeclared identifier 'strtoull'
    uint64_t start = strtoull(old_str, &str, 16);
                     ^
  /home/travis/build/bugsnag/bugsnag-android/sdk/src/main/jni/external/libunwindstack/Maps.cpp:76:18: error: use of undeclared identifier 'strtoull'
    uint64_t end = strtoull(old_str, &str, 16);
                   ^
  /home/travis/build/bugsnag/bugsnag-android/sdk/src/main/jni/external/libunwindstack/Maps.cpp:118:21: error: use of undeclared identifier 'strtoull'
    uint64_t offset = strtoull(old_str, &str, 16);
                      ^
  /home/travis/build/bugsnag/bugsnag-android/sdk/src/main/jni/external/libunwindstack/Maps.cpp:125:9: error: use of undeclared identifier 'strtoull'
    (void)strtoull(old_str, &str, 16);
          ^
  /home/travis/build/bugsnag/bugsnag-android/sdk/src/main/jni/external/libunwindstack/Maps.cpp:135:9: error: use of undeclared identifier 'strtoull'
    (void)strtoull(str, &str, 16);
          ^
  /home/travis/build/bugsnag/bugsnag-android/sdk/src/main/jni/external/libunwindstack/Maps.cpp:142:9: error: use of undeclared identifier 'strtoull'
    (void)strtoull(old_str, &str, 10);
          ^
  6 errors generated.
  ninja: build stopped: subcommand failed.
```

The getline code is unneeded, but the import for stdlib.h in getline.h was still used in Maps.cpp